### PR TITLE
Add Apple Silicon (MPS) support — OmniVoice + Higgs engines

### DIFF
--- a/reader/core/higgs_worker.py
+++ b/reader/core/higgs_worker.py
@@ -83,8 +83,22 @@ def main() -> None:
     local_only = bool(init.get("local_only"))
     model_seed = int(init.get("model_seed", 123))
     common = {"trust_remote_code": True, "local_files_only": local_only}
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    dtype = torch.bfloat16 if device == "cuda" else torch.float32
+    if torch.cuda.is_available():
+        device = "cuda"
+        dtype = torch.bfloat16
+    elif getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+        # Apple Silicon (Metal). float32 by default: bfloat16 audibly clips
+        # sentence onsets on MPS (verified on M-series hardware).
+        # Set AURIS_MPS_DTYPE=bf16 to trade quality for speed.
+        device = "mps"
+        dtype = (
+            torch.bfloat16
+            if os.environ.get("AURIS_MPS_DTYPE", "").lower() in {"bf16", "bfloat16"}
+            else torch.float32
+        )
+    else:
+        device = "cpu"
+        dtype = torch.float32
     # The adapter reports audio_head.weight as missing and initializes it while
     # from_pretrained() constructs the model. Set a stable initialization seed
     # before loading so repeated worker starts remain reproducible.
@@ -95,8 +109,8 @@ def main() -> None:
     model = AutoModelForCausalLM.from_pretrained(
         source, dtype=dtype, **common
     ).eval()
-    if device == "cuda":
-        model = model.to("cuda")
+    if device != "cpu":
+        model = model.to(device)
     # Keep the same loading sequence as source/higgs-tts-3-4b/app.py. The
     # Transformers loader applies the model's own weight-tying rules, so an
     # additional generic tie_weights() call is not needed.

--- a/reader/core/tts_engine.py
+++ b/reader/core/tts_engine.py
@@ -724,12 +724,26 @@ class TTSEngine:
             import torch
             from omnivoice import OmniVoice
 
-            device = "cuda" if self._cuda_available() else "cpu"
+            if self._cuda_available():
+                device = "cuda"
+            elif self._mps_available():
+                device = "mps"
+            else:
+                device = "cpu"
             if device == "cuda":
                 _enable_cuda_fast_paths()
                 # bf16 is faster on Ampere+ and avoids some fp16 underflow issues.
                 bf16_ok = bool(getattr(torch.cuda, "is_bf16_supported", lambda: False)())
                 dtype = torch.bfloat16 if bf16_ok else torch.float16
+            elif device == "mps":
+                # Apple Silicon (Metal). float32 by default: bfloat16 audibly
+                # clips sentence onsets on MPS (verified on M-series hardware).
+                # Set AURIS_MPS_DTYPE=bf16 to trade quality for speed.
+                dtype = (
+                    torch.bfloat16
+                    if os.environ.get("AURIS_MPS_DTYPE", "").lower() in {"bf16", "bfloat16"}
+                    else torch.float32
+                )
             else:
                 dtype = torch.float32
             log.info(
@@ -801,7 +815,7 @@ class TTSEngine:
                 except Exception:
                     log.info("OmniVoice model ready.")
             else:
-                log.info("OmniVoice model ready (CPU — expect low throughput).")
+                log.info("OmniVoice model ready (%s).", device.upper())
         except Exception as exc:
             self._error = str(exc)
             log.error("Failed to load OmniVoice: %s", exc)
@@ -814,6 +828,17 @@ class TTSEngine:
             import torch
 
             return torch.cuda.is_available()
+        except ImportError:
+            return False
+
+    @staticmethod
+    def _mps_available() -> bool:
+        """Apple Silicon Metal backend (macOS)."""
+        try:
+            import torch
+
+            mps = getattr(torch.backends, "mps", None)
+            return bool(mps is not None and mps.is_available())
         except ImportError:
             return False
 


### PR DESCRIPTION
## Summary

`setup.py` already detects Apple Silicon and installs the MPS-capable PyTorch build, but at runtime both engines only checked `torch.cuda.is_available()` and fell back to CPU on macOS. This PR makes the engines actually use the Metal (MPS) backend.

## Changes

- **`reader/core/tts_engine.py`** (OmniVoice)
  - Device selection is now `cuda → mps → cpu` via a new `_mps_available()` helper.
  - On MPS the model loads in `float32` by default. In listening tests on an M5 Pro, `bfloat16` audibly clipped sentence onsets (swallowed first syllables); `float32` fixed it. `AURIS_MPS_DTYPE=bf16` opts back into `bfloat16` for users who prefer speed over that artifact.
  - The non-CUDA "model ready" log line now reports the actual device instead of assuming CPU.
- **`reader/core/higgs_worker.py`** (Higgs TTS 3)
  - Same `cuda → mps → cpu` selection and dtype logic (guarded with `getattr(torch.backends, "mps", None)` so torch builds without the attribute are safe).
  - `model.to(device)` replaces the hard-coded `model.to("cuda")`.

## Notes

- OmniVoice upstream documents `device_map="mps"` as a supported path on Apple Silicon, so no library-side changes are needed.
- All CUDA-only paths (CUDA Graph / Triton acceleration, dedicated CUDA streams, dual export replicas, VRAM-based auto batch) are untouched; they no-op on MPS exactly as they do on CPU today.
- No behavior change on Windows/Linux CUDA or CPU setups.

## Testing

Tested end to end on a MacBook Pro (M5 Pro, 48 GB): install via `reader/setup.sh`, OmniVoice loads on MPS, Hungarian EPUB imports, playback and chapter generation work, and the full unit-test suite (94 tests) passes with the patch applied.

---

Szia! MacBookon szerettem volna magyar hangoskönyvet gyártani az Aurisszal, és a telepítő már felismeri az Apple Silicont, de a futtatás CPU-ra esett vissza — ez a PR bekapcsolja az MPS-t mindkét motornál. Köszi a remek projektet!