### PR TITLE
Include device and dtype in the audio cache key

### DIFF
--- a/reader/core/tts_engine.py
+++ b/reader/core/tts_engine.py
@@ -593,9 +593,17 @@ class TTSEngine:
         self._batch_size_cap: int | None = None
         self._accel_status: dict = {"effective": "off", "message": ""}
         self._generation_stream = None
+        # Device and dtype actually used for the loaded model, as a short tag
+        # that feeds the audio cache key. Empty until the model is loaded.
+        self._render_variant = ""
         os.makedirs(AUDIO_CACHE_DIR, exist_ok=True)
         os.makedirs(VOICE_REF_DIR, exist_ok=True)
         os.makedirs(VOICE_PROMPT_DIR, exist_ok=True)
+
+    @property
+    def render_variant(self) -> str:
+        """Device/dtype tag of the loaded model, empty before it loads."""
+        return self._render_variant
 
     def status(self) -> dict:
         resolved_path = self.model_path or _model_path_from_settings()
@@ -732,6 +740,9 @@ class TTSEngine:
                 dtype = torch.bfloat16 if bf16_ok else torch.float16
             else:
                 dtype = torch.float32
+            # Renders from different devices or dtypes are not interchangeable,
+            # so the cache key has to tell them apart.
+            self._render_variant = f"{device}/{dtype}"
             log.info(
                 "Loading OmniVoice from %s on %s (%s) ...",
                 self.model_path,
@@ -827,12 +838,17 @@ class TTSEngine:
         language: str | None = None,
         normalize_text: bool = False,
         num_step: int = DEFAULT_TTS_NUM_STEP,
+        variant: str = "",
     ) -> str:
         payload = (
             f"{text}|{instruct}|{ref_audio}|{ref_text}|{speed:.2f}|"
             f"{language or ''}|nt={int(bool(normalize_text))}|ns={int(num_step)}|"
             f"audio-cache-v={AUDIO_CACHE_FORMAT_VERSION}"
         )
+        # Appended only when supplied, so a caller that passes no variant keeps
+        # the historical key and existing cache entries stay valid.
+        if variant:
+            payload += f"|rv={variant}"
         return hashlib.md5(payload.encode("utf-8")).hexdigest()
 
     @staticmethod
@@ -1220,6 +1236,7 @@ class TTSEngine:
             language=language,
             normalize_text=normalize_text,
             num_step=num_step,
+            variant=self._render_variant,
         )
         path = self.cache_path(key)
 
@@ -1338,6 +1355,7 @@ class TTSEngine:
                 language=language,
                 normalize_text=normalize_text,
                 num_step=num_step,
+                variant=self._render_variant,
             )
             path = self.cache_path(key)
 

--- a/reader/tests/test_tts_cache_key_render_variant.py
+++ b/reader/tests/test_tts_cache_key_render_variant.py
@@ -1,0 +1,56 @@
+import unittest
+
+from core.tts_engine import TTSEngine
+
+
+class TtsCacheKeyRenderVariantTest(unittest.TestCase):
+    """The audio cache key must distinguish renders produced by different
+    devices or dtypes.
+
+    Without this, audio generated on one backend is served for a request on
+    another. A user who switches device, or who sets a dtype override, keeps
+    hearing the previously cached render and the change looks like it had no
+    effect.
+    """
+
+    ARGS = ("Hello there.", None, None, 1.0)
+    KWARGS = {
+        "ref_text": None,
+        "language": "en",
+        "normalize_text": False,
+        "num_step": 24,
+    }
+
+    def _key(self, **extra):
+        return TTSEngine.cache_key(*self.ARGS, **self.KWARGS, **extra)
+
+    def test_same_variant_is_stable(self):
+        self.assertEqual(
+            self._key(variant="mps/torch.float32"),
+            self._key(variant="mps/torch.float32"),
+        )
+
+    def test_dtype_change_changes_key(self):
+        self.assertNotEqual(
+            self._key(variant="mps/torch.float32"),
+            self._key(variant="mps/torch.bfloat16"),
+        )
+
+    def test_device_change_changes_key(self):
+        self.assertNotEqual(
+            self._key(variant="mps/torch.float32"),
+            self._key(variant="cpu/torch.float32"),
+        )
+
+    def test_omitted_variant_matches_empty_variant(self):
+        """Callers that pass no variant keep the historical key, so existing
+        cache entries and stored tts_segments.cache_key values stay valid."""
+        self.assertEqual(self._key(), self._key(variant=""))
+
+    def test_render_variant_is_empty_before_load(self):
+        engine = TTSEngine(model_path="/nonexistent/model")
+        self.assertEqual(engine.render_variant, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`TTSEngine.cache_key()` keys on text, instruct, reference audio, speed, language, `normalize_text` and `num_step`, but not on the device or dtype the audio was rendered with. Renders from different backends are not interchangeable, so audio generated on one device gets served for a request on another.

The visible symptom is that a device or dtype change appears to do nothing: already-cached segments keep replaying the old render.

I hit this while testing #1 on Apple Silicon. My first float32-vs-bfloat16 comparison was silently invalid, because the second run was served the first run's WAV rather than generating anything. It is not caused by #1 (the same reuse happens today when moving a library between a CUDA machine and a CPU-only one), but #1 adds a user-facing `AURIS_MPS_DTYPE` switch, which makes it much easier to trigger.

## Change

`TTSEngine` records the device and dtype it actually loaded with, exposes it as `render_variant`, and passes it to `cache_key()`.

The tag is appended **only when supplied**, so any caller that omits it produces exactly the historical key. That keeps existing cache files and stored `tts_segments.cache_key` values valid for callers that do not opt in.

## Verified

Same sentence, cache deliberately not cleared between runs, on an M-series Mac with #1 also applied so the dtype switch exists:

| Run | `render_variant` | Cache | Generation |
| --- | --- | --- | --- |
| float32 | `mps/torch.float32` | miss, generates | 2.30 s |
| bfloat16, same text | `mps/torch.bfloat16` | **miss, generates** | 1.22 s |
| float32 again, same text | `mps/torch.float32` | hit | 0.01 s |

Before the change, run 2 was a cache hit and no bfloat16 audio was ever produced. Caching within a single variant still works, as run 3 shows.

Test suite: **129 passed** (124 before, 5 new). New tests cover a stable key for an unchanged variant, a changed key for a dtype change, a changed key for a device change, an omitted variant matching the historical key, and `render_variant` being empty before load.

```
python -m unittest discover -s tests -p "test_*.py"
Ran 129 tests
OK
```

## Consequences worth deciding on

**One-time regeneration.** Once `generate()` passes a non-empty variant, keys change for everyone, so each library regenerates its cached audio once. That matches how the segment cache has been invalidated before (the `AUDIO_CACHE_FORMAT_VERSION` bump). Old WAVs are orphaned on disk rather than deleted, so nothing breaks; they are simply no longer referenced. Happy to add a cleanup step if you would rather not leave them.

If you would prefer to avoid the regeneration entirely, the alternative is to include the variant only when it is not the historical default, but that seemed more fragile than it is worth.

**`HiggsTTSEngine` has the same gap.** Its separate `cache_key()` includes `HIGGS_CACHE_VERSION`, prompt controls and generation settings, but also no device or dtype. I left it alone to keep this reviewable, since the Higgs dtype is chosen inside the worker process and the parent engine would need to learn it. Glad to do it as a follow-up if you want it.

Based on current `main`, independent of #1, and the two apply together cleanly in either order.
