### PR TITLE
Make the whole library card open the book

### DIFF
--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -1597,9 +1597,10 @@ code {
   padding: 0;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: rgba(0,0,0,.55);
-  backdrop-filter: blur(4px);
-  color: var(--text2);
+  background: #9c5252;
+  color: #fff;
+  /* Opaque, so legibility does not depend on the cover behind it, and red,
+     so Remove is never mistaken for the edit button beside it. */
   font-size: 0.95rem;
   line-height: 1;
   cursor: pointer;
@@ -1626,7 +1627,7 @@ code {
 }
 
 .card-remove:hover {
-  background: rgba(180,80,80,.85);
+  background: #b45050;
   color: #fff;
-  border-color: rgba(180,80,80,.9);
+  border-color: #b45050;
 }

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -1607,6 +1607,13 @@ code {
   pointer-events: none;
   transition: opacity .15s, background .15s, color .15s, border-color .15s,
     pointer-events 0s .15s allow-discrete;
+  /* allow-discrete is required, not optional. pointer-events is a discrete
+     property, so it is not transitionable under CSS Transitions Level 1 and
+     the familiar `transition: visibility 0s .15s` trick does not carry over:
+     visibility is explicitly animatable, pointer-events is not. Without
+     allow-discrete the delay is ignored entirely and pointer-events flips to
+     auto the instant :hover matches, so a fast click into the corner hits
+     Remove instead of the link beneath. Measured in Chromium 151. */
 }
 
 /* pointer-events matters as much as opacity here: an element at opacity 0 still

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -474,6 +474,7 @@ code {
   background: var(--bg3);
   display: flex; align-items: center; justify-content: center;
   overflow: hidden;
+  position: relative;
 }
 .book-cover-placeholder {
   width: 100%; height: 100%;
@@ -1583,4 +1584,50 @@ code {
   .font-controls .btn {
     flex: 1 0 auto;
   }
+}
+
+/* The whole card opens the book. Stretching the existing anchor keeps keyboard
+   activation, right-click and open-in-new-tab working, which a click handler on
+   the card div would not. .book-card is already position: relative. */
+.book-actions a::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
+
+/* Remove sits top-left because .book-type-badge already owns top-right. */
+.card-remove {
+  position: absolute;
+  top: 8px; left: 8px;
+  z-index: 2;
+  width: 24px; height: 24px;
+  display: flex; align-items: center; justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: rgba(0,0,0,.55);
+  backdrop-filter: blur(4px);
+  color: var(--text2);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .15s, background .15s, color .15s, border-color .15s,
+    pointer-events 0s .15s allow-discrete;
+}
+
+/* pointer-events matters as much as opacity here: an element at opacity 0 still
+   receives clicks, so without this the corner of every cover would be an
+   invisible delete button sitting where the user clicks to open the book. */
+.book-card:hover .card-remove,
+.card-remove:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.card-remove:hover {
+  background: rgba(180,80,80,.85);
+  color: #fff;
+  border-color: rgba(180,80,80,.9);
 }

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -531,14 +531,6 @@ code {
   border: 1px solid var(--border);
 }
 .book-actions a:hover { background: var(--accent); color: var(--bg); text-decoration: none; }
-.book-actions .del-btn {
-  background: transparent; color: var(--text3);
-  border: 1px solid var(--border);
-}
-.book-actions .del-btn:hover {
-  background: rgba(180,80,80,.1); color: #c88080;
-  border-color: rgba(180,80,80,.3);
-}
 
 .empty-library {
   text-align: center; padding: 80px 20px; color: var(--text2);

--- a/reader/static/js/library.js
+++ b/reader/static/js/library.js
@@ -41,7 +41,12 @@ async function loadBooks() {
 
     return `
     <div class="book-card" data-id="${b.id}">
-      <div class="book-cover">${coverHtml}</div>
+      <div class="book-cover">
+        ${coverHtml}
+        <button class="card-remove" title="Remove from library"
+                aria-label="Remove ${esc(b.title)} from library"
+                onclick="deleteBook(event,${b.id})">&times;</button>
+      </div>
       <span class="book-type-badge">${esc(b.file_type)}</span>
       <div class="book-info">
         <div class="book-title">${esc(b.title)}</div>
@@ -54,7 +59,6 @@ async function loadBooks() {
       </div>
       <div class="book-actions">
         <a href="/reader/${b.id}">${actionLabel}</a>
-        <button class="del-btn" onclick="deleteBook(event,${b.id})">Remove</button>
       </div>
     </div>`;
   }).join('');


### PR DESCRIPTION
Makes the whole library card open the book, and moves Remove onto the cover.

## The problem

`.book-card` has `cursor: pointer` and a hover treatment that lifts the card, adds a shadow and highlights the border. Every one of those signals says "click me". But `library.js` attaches no click handler to the card: only the small `<a>` in the footer navigates, so the card advertises an interaction it does not have and the user has to aim at the button instead.

There is a hint the card handler was once intended: `deleteBook(e, id)` opens with `e.stopPropagation()`, which is only meaningful when an ancestor click handler exists. After this change it finally is.

## What changed

**The card opens the book.** The existing `<a href="/reader/N">` is stretched over the card with an `::after` overlay:

```css
.book-actions a::after { content: ''; position: absolute; inset: 0; }
```

`.book-card` was already `position: relative`, so no new positioning context was needed.

This is deliberately not a click handler on the card `div`. Keeping a real anchor means keyboard activation still works, Enter still opens the book, right-click and middle-click and open-in-new-tab still work, and a screen reader still announces a link. Wrapping the whole card in an anchor was not an option either, since a `<button>` inside an `<a>` is invalid HTML.

**Remove moved onto the cover** as an icon revealed on hover or keyboard focus, so the footer now holds a single unambiguous action (`Continue` or `Read`, wording unchanged). It sits top-left because `.book-type-badge` already owns `top: 8px; right: 8px`, and moving that badge seemed out of scope.

`confirm('Remove this book from the library?')` is untouched and still guards the delete.

**Removed `.book-actions .del-btn` and its `:hover`**, which this change orphaned.

## One subtlety worth not un-doing

Remove is hidden with `opacity: 0` rather than `display: none` or `visibility: hidden`, so it stays in the tab order and can be reached without a mouse. But an element at `opacity: 0` still receives clicks, so it also needs `pointer-events: none`, otherwise the corner of every cover becomes an invisible delete button sitting exactly where a user clicks to open the book.

Flipping `pointer-events` on `:hover` alone is not enough either, because it flips the instant hover matches, before the button has faded in. So the rule delays it:

```css
transition: opacity .15s, ..., pointer-events 0s .15s allow-discrete;
```

`allow-discrete` is required rather than decorative. `pointer-events` is a discrete property and is not transitionable under CSS Transitions Level 1, so the familiar `transition: visibility 0s .15s` trick does not carry over: `visibility` is explicitly animatable and `pointer-events` is not. Measured in Chromium 151:

| | immediately on hover | after 250 ms |
| --- | --- | --- |
| without `allow-discrete` | `auto` | `auto` |
| with `allow-discrete` | `none` | `auto` |

Without it the delay is ignored entirely and a fast click into the corner hits Remove instead of the link beneath. There is a comment in the CSS saying so, since the obvious "simplification" silently reintroduces the bug.

## Verification

No frontend test framework exists in this project and this PR does not add one. Following `AGENTS.md` ("For every browser-based UI check, use local Playwright... Capture a screenshot and inspect browser console errors"), a throwaway Playwright script, not committed, drove a running instance and checked:

1. Clicking the card body opens `/reader/<id>`.
2. Clicking Remove does not navigate and opens the confirm dialog.
3. Dismissing that dialog leaves the book in the library.
4. Remove is invisible at rest and visible on hover.
5. A cold click into the cover corner, without hovering first, opens the book rather than triggering Remove. This is the check that guards the `pointer-events` behavior above.
6. The book link is focusable and Enter opens the book.
7. Remove is focusable and becomes visible when focused.
8. No browser console errors.

All checks pass. Screenshots at rest and on hover were reviewed: Remove does not overlap the file-type badge, and the footer action spans the full card width now that it is the only button.

The Python suite still passes at 124 tests, which is the evidence that nothing outside the two frontend files was touched.

## Scope

Two files, `reader/static/js/library.js` and `reader/static/css/style.css`. No backend, template, API or dependency change.

Undo for a removed book is deliberately not included; that would need server-side soft deletion and is a larger feature. The `confirm()` dialog remains the guard.
