### PR TITLE
Edit a book's title, author and language

### DIFF
--- a/reader/app.py
+++ b/reader/app.py
@@ -5,6 +5,7 @@ Offline Ebook Reader — Flask application.
 import base64
 import logging
 import os
+import re
 import threading
 import uuid
 
@@ -762,6 +763,59 @@ def delete_book(book_id):
     with get_conn() as conn:
         conn.execute('DELETE FROM books WHERE id=?', (book_id,))
     return jsonify({'ok': True})
+
+
+# Language codes accepted for a book: "en", "hu", "ro", or a regional form
+# such as "zh-cn". Deliberately permissive, because the value is passed
+# through to the TTS engine and no whitelist of supported languages exists.
+_BOOK_LANGUAGE_RE = re.compile(r'^[a-z]{2}(-[a-z]{2,4})?$')
+
+
+@app.route('/api/books/<int:book_id>', methods=['PUT'])
+def update_book(book_id):
+    body = request.get_json(force=True) or {}
+    allowed = {'title', 'author', 'language'}
+    # The whitelist is a security boundary as well as a filter: file_path and
+    # file_type live in the same row and must not be settable from a request.
+    updates = {k: str(body[k] or '').strip() for k in allowed if k in body}
+    if not updates:
+        return jsonify({'error': 'Nothing to update'}), 400
+
+    if 'title' in updates and not updates['title']:
+        return jsonify({'error': 'Title cannot be empty'}), 400
+    if 'author' in updates and not updates['author']:
+        updates['author'] = 'Unknown Author'
+    if 'language' in updates:
+        updates['language'] = updates['language'].lower()
+        if not _BOOK_LANGUAGE_RE.match(updates['language']):
+            return jsonify({
+                'error': 'Language must be a code such as en, hu, ro or zh-cn.'
+            }), 400
+
+    with get_conn() as conn:
+        book = conn.execute(
+            'SELECT language FROM books WHERE id=?', (book_id,)
+        ).fetchone()
+        if not book:
+            return jsonify({'error': 'Book not found'}), 404
+        # Language is part of the audio cache key, but an already-generated
+        # segment is served from disk without being re-keyed, so a language
+        # change has to discard the cached audio or the book keeps its old
+        # pronunciation forever. A title or author edit changes nothing audible.
+        language_changed = (
+            'language' in updates
+            and updates['language'] != (book['language'] or '')
+        )
+        set_clause = ', '.join(f'{k}=?' for k in updates)
+        conn.execute(
+            f'UPDATE books SET {set_clause} WHERE id=?',
+            (*updates.values(), book_id),
+        )
+
+    if language_changed:
+        _clear_book_tts_segments(book_id)
+
+    return jsonify({'ok': True, 'segments_cleared': language_changed})
 
 
 # ════════════════════════════════════════════════════════════════════════════

--- a/reader/app.py
+++ b/reader/app.py
@@ -774,7 +774,11 @@ _BOOK_LANGUAGE_RE = re.compile(r'^[a-z]{2}(-[a-z]{2,4})?$')
 @app.route('/api/books/<int:book_id>', methods=['PUT'])
 def update_book(book_id):
     body = request.get_json(force=True) or {}
-    allowed = {'title', 'author', 'language'}
+    # A fixed-order tuple, not a set: iteration order feeds directly into the
+    # 400 error message below, and a set's order is not guaranteed, so which
+    # field got named would vary between runs when a body carries more than
+    # one non-string value.
+    allowed = ('title', 'author', 'language')
     # The whitelist is a security boundary as well as a filter: file_path and
     # file_type live in the same row and must not be settable from a request.
     updates = {}
@@ -812,9 +816,15 @@ def update_book(book_id):
         # segment is served from disk without being re-keyed, so a language
         # change has to discard the cached audio or the book keeps its old
         # pronunciation forever. A title or author edit changes nothing audible.
+        #
+        # Compare normalized values. Stored languages are not guaranteed
+        # lowercase: the EPUB parser writes the raw dc:language prefix, so a
+        # book can hold "EN" while the submitted value is always lowercased.
+        # Without this, a title-only edit that echoes the language back would
+        # look like a change and would discard every generated segment.
+        stored_language = (book['language'] or '').strip().lower()
         language_changed = (
-            'language' in updates
-            and updates['language'] != (book['language'] or '')
+            'language' in updates and updates['language'] != stored_language
         )
         set_clause = ', '.join(f'{k}=?' for k in updates)
         conn.execute(

--- a/reader/app.py
+++ b/reader/app.py
@@ -703,7 +703,7 @@ def _store_character_analysis(
 def list_books():
     with get_conn() as conn:
         rows = conn.execute(
-            'SELECT b.id, b.title, b.author, b.file_type, b.cover_b64, b.added_at, '
+            'SELECT b.id, b.title, b.author, b.language, b.file_type, b.cover_b64, b.added_at, '
             'b.last_read, b.total_chapters, b.character_analysis_status, '
             'b.character_analysis_message, b.character_analysis_provider, '
             'b.character_analysis_model, rp.chapter_id AS progress_chapter_id, '

--- a/reader/app.py
+++ b/reader/app.py
@@ -777,7 +777,17 @@ def update_book(book_id):
     allowed = {'title', 'author', 'language'}
     # The whitelist is a security boundary as well as a filter: file_path and
     # file_type live in the same row and must not be settable from a request.
-    updates = {k: str(body[k] or '').strip() for k in allowed if k in body}
+    updates = {}
+    for key in allowed:
+        if key not in body:
+            continue
+        value = body[key]
+        # Reject non-string JSON types rather than coercing them. A number, a
+        # list or an object would otherwise be written into the column as its
+        # Python repr, and a numeric 0 would silently become an empty string.
+        if not isinstance(value, str):
+            return jsonify({'error': f'{key} must be text.'}), 400
+        updates[key] = value.strip()
     if not updates:
         return jsonify({'error': 'Nothing to update'}), 400
 

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -1590,7 +1590,7 @@ code {
 /* Remove sits top-left because .book-type-badge already owns top-right. */
 .card-remove {
   position: absolute;
-  top: 8px; left: 8px;
+  top: 8px; left: 40px;
   z-index: 2;
   width: 24px; height: 24px;
   display: flex; align-items: center; justify-content: center;
@@ -1630,4 +1630,65 @@ code {
   background: #b45050;
   color: #fff;
   border-color: #b45050;
+}
+
+.field-label {
+  display: block;
+  margin: 10px 0 4px;
+  font-size: 0.72rem;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.field-input {
+  width: 100%;
+  padding: 7px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--text);
+  font-family: var(--ui-font);
+  font-size: 0.86rem;
+}
+.field-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.field-hint {
+  margin-top: 8px;
+  font-size: 0.72rem;
+  color: var(--text3);
+  line-height: 1.4;
+}
+
+/* Sits beside .card-remove on the cover, sharing its reveal behavior. */
+.card-edit {
+  position: absolute;
+  top: 8px; left: 8px;
+  z-index: 2;
+  width: 24px; height: 24px;
+  display: flex; align-items: center; justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: rgba(0,0,0,.55);
+  backdrop-filter: blur(4px);
+  color: var(--text2);
+  font-size: 0.7rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .15s, background .15s, color .15s, border-color .15s,
+    pointer-events 0s .15s allow-discrete;
+}
+.book-card:hover .card-edit,
+.card-edit:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.card-edit:hover {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
 }

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -1632,7 +1632,11 @@ code {
   border-color: #b45050;
 }
 
-.field-label {
+/* Scoped under #edit-dialog (rather than left as bare .field-* classes) so
+   these generic names cannot collide with unrelated markup elsewhere; the
+   project already has .text-input for the same purpose on other pages, but
+   renaming the classes in library.html is outside this change's scope. */
+#edit-dialog .field-label {
   display: block;
   margin: 10px 0 4px;
   font-size: 0.72rem;
@@ -1640,7 +1644,7 @@ code {
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
-.field-input {
+#edit-dialog .field-input {
   width: 100%;
   padding: 7px 10px;
   border-radius: 4px;
@@ -1650,11 +1654,11 @@ code {
   font-family: var(--ui-font);
   font-size: 0.86rem;
 }
-.field-input:focus {
+#edit-dialog .field-input:focus {
   outline: none;
   border-color: var(--accent);
 }
-.field-hint {
+#edit-dialog .field-hint {
   margin-top: 8px;
   font-size: 0.72rem;
   color: var(--text3);

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -1597,9 +1597,10 @@ code {
   padding: 0;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: rgba(0,0,0,.55);
-  backdrop-filter: blur(4px);
-  color: var(--text2);
+  background: #9c5252;
+  color: #fff;
+  /* Opaque, so legibility does not depend on the cover behind it, and red,
+     so Remove is never mistaken for the edit button beside it. */
   font-size: 0.95rem;
   line-height: 1;
   cursor: pointer;
@@ -1626,7 +1627,7 @@ code {
 }
 
 .card-remove:hover {
-  background: rgba(180,80,80,.85);
+  background: #b45050;
   color: #fff;
-  border-color: rgba(180,80,80,.9);
+  border-color: #b45050;
 }

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -1607,6 +1607,13 @@ code {
   pointer-events: none;
   transition: opacity .15s, background .15s, color .15s, border-color .15s,
     pointer-events 0s .15s allow-discrete;
+  /* allow-discrete is required, not optional. pointer-events is a discrete
+     property, so it is not transitionable under CSS Transitions Level 1 and
+     the familiar `transition: visibility 0s .15s` trick does not carry over:
+     visibility is explicitly animatable, pointer-events is not. Without
+     allow-discrete the delay is ignored entirely and pointer-events flips to
+     auto the instant :hover matches, so a fast click into the corner hits
+     Remove instead of the link beneath. Measured in Chromium 151. */
 }
 
 /* pointer-events matters as much as opacity here: an element at opacity 0 still

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -474,6 +474,7 @@ code {
   background: var(--bg3);
   display: flex; align-items: center; justify-content: center;
   overflow: hidden;
+  position: relative;
 }
 .book-cover-placeholder {
   width: 100%; height: 100%;
@@ -1583,4 +1584,50 @@ code {
   .font-controls .btn {
     flex: 1 0 auto;
   }
+}
+
+/* The whole card opens the book. Stretching the existing anchor keeps keyboard
+   activation, right-click and open-in-new-tab working, which a click handler on
+   the card div would not. .book-card is already position: relative. */
+.book-actions a::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
+
+/* Remove sits top-left because .book-type-badge already owns top-right. */
+.card-remove {
+  position: absolute;
+  top: 8px; left: 8px;
+  z-index: 2;
+  width: 24px; height: 24px;
+  display: flex; align-items: center; justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: rgba(0,0,0,.55);
+  backdrop-filter: blur(4px);
+  color: var(--text2);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .15s, background .15s, color .15s, border-color .15s,
+    pointer-events 0s .15s allow-discrete;
+}
+
+/* pointer-events matters as much as opacity here: an element at opacity 0 still
+   receives clicks, so without this the corner of every cover would be an
+   invisible delete button sitting where the user clicks to open the book. */
+.book-card:hover .card-remove,
+.card-remove:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.card-remove:hover {
+  background: rgba(180,80,80,.85);
+  color: #fff;
+  border-color: rgba(180,80,80,.9);
 }

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -531,14 +531,6 @@ code {
   border: 1px solid var(--border);
 }
 .book-actions a:hover { background: var(--accent); color: var(--bg); text-decoration: none; }
-.book-actions .del-btn {
-  background: transparent; color: var(--text3);
-  border: 1px solid var(--border);
-}
-.book-actions .del-btn:hover {
-  background: rgba(180,80,80,.1); color: #c88080;
-  border-color: rgba(180,80,80,.3);
-}
 
 .empty-library {
   text-align: center; padding: 80px 20px; color: var(--text2);

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -1675,9 +1675,10 @@ code {
   padding: 0;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: rgba(0,0,0,.55);
-  backdrop-filter: blur(4px);
-  color: var(--text2);
+  /* Opaque accent, so legibility does not depend on the cover behind it and
+     Edit is never mistaken for the red Remove button beside it. */
+  background: var(--accent);
+  color: var(--bg);
   font-size: 0.7rem;
   line-height: 1;
   cursor: pointer;
@@ -1692,7 +1693,9 @@ code {
   pointer-events: auto;
 }
 .card-edit:hover {
-  background: var(--accent);
+  /* Brightens rather than darkening to --accent2: that token gives only
+     4.34:1 against the glyph, below the 4.5 bar every other value here meets. */
+  background: #d8b47e;
   color: var(--bg);
-  border-color: var(--accent);
+  border-color: #d8b47e;
 }

--- a/reader/static/js/library.js
+++ b/reader/static/js/library.js
@@ -43,6 +43,9 @@ async function loadBooks() {
     <div class="book-card" data-id="${b.id}">
       <div class="book-cover">
         ${coverHtml}
+        <button class="card-edit" title="Edit book details"
+                aria-label="Edit details for ${esc(b.title)}"
+                onclick="openEditDialog(event,${b.id})">&#9998;</button>
         <button class="card-remove" title="Remove from library"
                 aria-label="Remove ${esc(b.title)} from library"
                 onclick="deleteBook(event,${b.id})">&times;</button>
@@ -69,6 +72,74 @@ async function deleteBook(e, id) {
   if (!confirm('Remove this book from the library?')) return;
   await fetch(`/api/books/${id}`, { method: 'DELETE' });
   loadBooks();
+}
+
+let editingBookId = null;
+let editingOriginalLanguage = '';
+
+async function openEditDialog(e, id) {
+  // The whole card is a link to the reader, so this click must not open it.
+  e.stopPropagation();
+  e.preventDefault();
+  const books = await fetch('/api/books').then(r => r.json());
+  const book = books.find(b => b.id === id);
+  if (!book) return;
+
+  editingBookId = id;
+  editingOriginalLanguage = book.language || '';
+  document.getElementById('edit-title').value = book.title || '';
+  document.getElementById('edit-author').value = book.author || '';
+  document.getElementById('edit-language').value = editingOriginalLanguage;
+  const status = document.getElementById('edit-status');
+  status.textContent = '';
+  status.className = 'import-status hidden';
+  document.getElementById('edit-dialog').classList.remove('hidden');
+  document.getElementById('edit-title').focus();
+}
+
+function closeEditDialog() {
+  document.getElementById('edit-dialog').classList.add('hidden');
+  editingBookId = null;
+}
+
+async function saveBookEdits() {
+  if (editingBookId === null) return;
+  const title = document.getElementById('edit-title').value.trim();
+  const author = document.getElementById('edit-author').value.trim();
+  const language = document.getElementById('edit-language').value.trim().toLowerCase();
+  const status = document.getElementById('edit-status');
+  const button = document.getElementById('save-edit-btn');
+
+  if (!title) {
+    status.textContent = 'Title cannot be empty.';
+    status.className = 'import-status error';
+    return;
+  }
+  // Only warn when the language actually changed, since that is the only
+  // edit that discards generated audio.
+  if (language !== editingOriginalLanguage &&
+      !confirm('Changing the language discards this book’s generated audio '
+               + 'so it can be read again with the new pronunciation. Continue?')) {
+    return;
+  }
+
+  button.disabled = true;
+  try {
+    const r = await fetch(`/api/books/${editingBookId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, author, language }),
+    });
+    const d = await r.json();
+    if (!r.ok || d.error) throw new Error(d.error || 'Save failed');
+    closeEditDialog();
+    loadBooks();
+  } catch (err) {
+    status.textContent = err.message;
+    status.className = 'import-status error';
+  } finally {
+    button.disabled = false;
+  }
 }
 
 let pendingImportFile = null;

--- a/reader/static/js/library.js
+++ b/reader/static/js/library.js
@@ -83,13 +83,24 @@ async function openEditDialog(e, id) {
   e.preventDefault();
   const books = await fetch('/api/books').then(r => r.json());
   const book = books.find(b => b.id === id);
-  if (!book) return;
+  if (!book) {
+    // The book was removed elsewhere (another tab, another device) between
+    // the grid rendering and this click. Refresh instead of silently doing
+    // nothing, so the grid stops showing a card whose edit button is dead.
+    alert('This book was removed. Refreshing the library.');
+    loadBooks();
+    return;
+  }
 
   editingBookId = id;
-  editingOriginalLanguage = book.language || '';
+  // Normalized the same way the server compares it: stored languages are not
+  // guaranteed lowercase (the EPUB parser writes the raw dc:language prefix),
+  // so without this a book stored as "EN" would make an unrelated edit look
+  // like a language change and warn about discarding audio that never moved.
+  editingOriginalLanguage = (book.language || '').trim().toLowerCase();
   document.getElementById('edit-title').value = book.title || '';
   document.getElementById('edit-author').value = book.author || '';
-  document.getElementById('edit-language').value = editingOriginalLanguage;
+  document.getElementById('edit-language').value = book.language || '';
   const status = document.getElementById('edit-status');
   status.textContent = '';
   status.className = 'import-status hidden';
@@ -125,13 +136,23 @@ async function saveBookEdits() {
 
   button.disabled = true;
   try {
+    // Omit language entirely when there is nothing meaningful to send: a
+    // book with no stored language opens the dialog with an empty language
+    // field, and always sending it would fail the endpoint's format check
+    // for a field the user never touched, blocking even a title-only fix.
+    const payload = { title, author };
+    if (language || editingOriginalLanguage) payload.language = language;
     const r = await fetch(`/api/books/${editingBookId}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, author, language }),
+      body: JSON.stringify(payload),
     });
     const d = await r.json();
     if (!r.ok || d.error) throw new Error(d.error || 'Save failed');
+    if (d.segments_cleared) {
+      alert('Language changed. This book’s generated audio was cleared and '
+            + 'will be regenerated with the new pronunciation.');
+    }
     closeEditDialog();
     loadBooks();
   } catch (err) {

--- a/reader/static/js/library.js
+++ b/reader/static/js/library.js
@@ -41,7 +41,12 @@ async function loadBooks() {
 
     return `
     <div class="book-card" data-id="${b.id}">
-      <div class="book-cover">${coverHtml}</div>
+      <div class="book-cover">
+        ${coverHtml}
+        <button class="card-remove" title="Remove from library"
+                aria-label="Remove ${esc(b.title)} from library"
+                onclick="deleteBook(event,${b.id})">&times;</button>
+      </div>
       <span class="book-type-badge">${esc(b.file_type)}</span>
       <div class="book-info">
         <div class="book-title">${esc(b.title)}</div>
@@ -54,7 +59,6 @@ async function loadBooks() {
       </div>
       <div class="book-actions">
         <a href="/reader/${b.id}">${actionLabel}</a>
-        <button class="del-btn" onclick="deleteBook(event,${b.id})">Remove</button>
       </div>
     </div>`;
   }).join('');

--- a/reader/templates/library.html
+++ b/reader/templates/library.html
@@ -52,6 +52,46 @@
     </div>
   </div>
 </div>
+
+<div class="modal-overlay hidden" id="edit-dialog" onclick="closeEditDialog()">
+  <div class="modal" role="dialog" aria-modal="true"
+       aria-labelledby="edit-dialog-title" onclick="event.stopPropagation()">
+    <div class="modal-title" id="edit-dialog-title">Edit book details</div>
+
+    <label class="field-label" for="edit-title">Title</label>
+    <input class="field-input" id="edit-title" type="text" autocomplete="off">
+
+    <label class="field-label" for="edit-author">Author</label>
+    <input class="field-input" id="edit-author" type="text" autocomplete="off"
+           placeholder="Unknown Author">
+
+    <label class="field-label" for="edit-language">Language</label>
+    <input class="field-input" id="edit-language" type="text" autocomplete="off"
+           list="edit-language-options" placeholder="en">
+    <datalist id="edit-language-options">
+      <option value="en">English</option>
+      <option value="hu">Hungarian</option>
+      <option value="ro">Romanian</option>
+      <option value="de">German</option>
+      <option value="fr">French</option>
+      <option value="es">Spanish</option>
+      <option value="it">Italian</option>
+      <option value="zh">Chinese</option>
+      <option value="ja">Japanese</option>
+    </datalist>
+    <div class="field-hint">
+      Language affects pronunciation. Changing it discards this book's
+      generated audio so it can be read again with the new pronunciation.
+    </div>
+
+    <div class="import-status hidden" id="edit-status"></div>
+    <div class="modal-footer">
+      <button class="btn btn-ghost" type="button" onclick="closeEditDialog()">Cancel</button>
+      <button class="btn btn-primary" type="button" id="save-edit-btn"
+              onclick="saveBookEdits()">Save</button>
+    </div>
+  </div>
+</div>
 {% endblock %}
 {% block scripts %}
 <script src="/static/js/library.js"></script>

--- a/reader/tests/test_book_metadata_api.py
+++ b/reader/tests/test_book_metadata_api.py
@@ -1,0 +1,159 @@
+"""Tests for editing a book's title, author and language.
+
+The destructive behavior under test is that changing the language clears the
+book's cached audio, because language is part of the audio cache key but an
+already-generated segment is served from disk without being re-keyed. A title
+or author edit must never clear audio.
+"""
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import app as app_module
+from core import database
+from core import settings as app_settings
+
+
+class BookMetadataApiTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._original = (
+            database.DB_PATH,
+            app_settings.SETTINGS_FILE,
+            app_module._startup_complete,
+        )
+        database.DB_PATH = os.path.join(self.tmp.name, 'reader.db')
+        app_settings.SETTINGS_FILE = Path(self.tmp.name) / 'settings.json'
+        app_module._startup_complete = True
+        database.init_db()
+        with database.get_conn() as conn:
+            conn.execute(
+                "INSERT INTO books (id, title, author, file_path, file_type, language) "
+                "VALUES (1, 'Unknown Title', 'Unknown Author', '/books/x.pdf', 'pdf', 'en')"
+            )
+            conn.execute(
+                "INSERT INTO chapters (id, book_id, title, order_num, content) "
+                "VALUES (1, 1, 'Chapter 1', 0, 'Text.')"
+            )
+            conn.execute(
+                "INSERT INTO tts_segments "
+                "(book_id, chapter_id, segment_index, text, enriched_text, cache_key, audio_path) "
+                "VALUES (1, 1, 0, 'Text.', 'Text.', 'key-1', '/audio/one.wav')"
+            )
+        app_module.app.config['TESTING'] = True
+        self.client = app_module.app.test_client()
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        (
+            database.DB_PATH,
+            app_settings.SETTINGS_FILE,
+            app_module._startup_complete,
+        ) = self._original
+        self.tmp.cleanup()
+
+    def _book(self):
+        with database.get_conn() as conn:
+            return dict(conn.execute('SELECT * FROM books WHERE id=1').fetchone())
+
+    def _segment_count(self):
+        with database.get_conn() as conn:
+            return conn.execute(
+                'SELECT COUNT(*) FROM tts_segments WHERE book_id=1'
+            ).fetchone()[0]
+
+    def test_updates_title_and_author(self):
+        response = self.client.put(
+            '/api/books/1', json={'title': 'The Fur Coat', 'author': 'Valics Lehel'}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {'ok': True, 'segments_cleared': False})
+        book = self._book()
+        self.assertEqual(book['title'], 'The Fur Coat')
+        self.assertEqual(book['author'], 'Valics Lehel')
+
+    def test_title_only_edit_keeps_generated_audio(self):
+        """The guard against destroying hours of synthesis on a rename."""
+        response = self.client.put('/api/books/1', json={'title': 'Renamed'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.get_json()['segments_cleared'])
+        self.assertEqual(self._segment_count(), 1)
+
+    def test_language_change_clears_generated_audio(self):
+        response = self.client.put('/api/books/1', json={'language': 'ro'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()['segments_cleared'])
+        self.assertEqual(self._segment_count(), 0)
+        self.assertEqual(self._book()['language'], 'ro')
+
+    def test_unchanged_language_does_not_clear_audio(self):
+        response = self.client.put(
+            '/api/books/1', json={'title': 'Renamed', 'language': 'en'}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.get_json()['segments_cleared'])
+        self.assertEqual(self._segment_count(), 1)
+
+    def test_language_is_lowercased(self):
+        response = self.client.put('/api/books/1', json={'language': 'RO'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._book()['language'], 'ro')
+
+    def test_regional_language_code_is_accepted(self):
+        response = self.client.put('/api/books/1', json={'language': 'zh-cn'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._book()['language'], 'zh-cn')
+
+    def test_empty_title_is_rejected(self):
+        response = self.client.put('/api/books/1', json={'title': '   '})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Title', response.get_json()['error'])
+        self.assertEqual(self._book()['title'], 'Unknown Title')
+
+    def test_empty_author_becomes_unknown_author(self):
+        response = self.client.put('/api/books/1', json={'author': '  '})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._book()['author'], 'Unknown Author')
+
+    def test_malformed_language_is_rejected(self):
+        response = self.client.put('/api/books/1', json={'language': 'Romanian'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self._book()['language'], 'en')
+        self.assertEqual(self._segment_count(), 1)
+
+    def test_unknown_book_returns_404(self):
+        response = self.client.put('/api/books/999', json={'title': 'Nope'})
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_body_without_known_fields_is_rejected(self):
+        response = self.client.put('/api/books/1', json={'colour': 'blue'})
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_file_path_cannot_be_changed(self):
+        """The allowed whitelist is a security boundary: file_path and
+        file_type live in the same row as the editable fields."""
+        response = self.client.put(
+            '/api/books/1',
+            json={'title': 'Renamed', 'file_path': '/etc/passwd', 'file_type': 'txt'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        book = self._book()
+        self.assertEqual(book['file_path'], '/books/x.pdf')
+        self.assertEqual(book['file_type'], 'pdf')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/reader/tests/test_book_metadata_api.py
+++ b/reader/tests/test_book_metadata_api.py
@@ -90,6 +90,34 @@ class BookMetadataApiTest(unittest.TestCase):
         self.assertEqual(self._segment_count(), 0)
         self.assertEqual(self._book()['language'], 'ro')
 
+    def test_uppercase_stored_language_is_not_seen_as_changed(self):
+        """The EPUB parser stores the raw dc:language prefix uncased, so a
+        book can hold 'EN'. Submitting the lowercased equivalent alongside an
+        unrelated title edit must not look like a language change."""
+        with database.get_conn() as conn:
+            conn.execute("UPDATE books SET language='EN' WHERE id=1")
+
+        response = self.client.put(
+            '/api/books/1', json={'title': 'Fixed Title', 'author': 'A', 'language': 'en'}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.get_json()['segments_cleared'])
+        self.assertEqual(self._segment_count(), 1)
+        self.assertEqual(self._book()['title'], 'Fixed Title')
+
+    def test_null_language_accepts_title_only_update(self):
+        """A book with no stored language cannot echo one back, so the field
+        must be optional: this must succeed rather than fail the language
+        format check on an empty string."""
+        with database.get_conn() as conn:
+            conn.execute("UPDATE books SET language=NULL WHERE id=1")
+
+        response = self.client.put('/api/books/1', json={'title': 'Fixed Title'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._book()['title'], 'Fixed Title')
+
     def test_unchanged_language_does_not_clear_audio(self):
         response = self.client.put(
             '/api/books/1', json={'title': 'Renamed', 'language': 'en'}
@@ -149,11 +177,18 @@ class BookMetadataApiTest(unittest.TestCase):
         self.assertEqual(self._book()['title'], 'Unknown Title')
 
     def test_list_author_is_rejected(self):
+        # Seeded to a value distinct from 'Unknown Author', the default the
+        # server would fall back to for an empty string, so this assertion
+        # can actually tell "rejected" apart from "wrote the normalized
+        # default" instead of passing either way.
+        with database.get_conn() as conn:
+            conn.execute("UPDATE books SET author='Original Author' WHERE id=1")
+
         response = self.client.put('/api/books/1', json={'author': [1, 2]})
 
         self.assertEqual(response.status_code, 400)
         self.assertIn('author', response.get_json()['error'])
-        self.assertEqual(self._book()['author'], 'Unknown Author')
+        self.assertEqual(self._book()['author'], 'Original Author')
 
     def test_zero_title_is_not_coerced_to_empty(self):
         response = self.client.put('/api/books/1', json={'title': 0})

--- a/reader/tests/test_book_metadata_api.py
+++ b/reader/tests/test_book_metadata_api.py
@@ -141,6 +141,27 @@ class BookMetadataApiTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_numeric_title_is_rejected(self):
+        response = self.client.put('/api/books/1', json={'title': 42})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('title', response.get_json()['error'])
+        self.assertEqual(self._book()['title'], 'Unknown Title')
+
+    def test_list_author_is_rejected(self):
+        response = self.client.put('/api/books/1', json={'author': [1, 2]})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('author', response.get_json()['error'])
+        self.assertEqual(self._book()['author'], 'Unknown Author')
+
+    def test_zero_title_is_not_coerced_to_empty(self):
+        response = self.client.put('/api/books/1', json={'title': 0})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('title', response.get_json()['error'])
+        self.assertNotIn('Title cannot be empty', response.get_json()['error'])
+
     def test_file_path_cannot_be_changed(self):
         """The allowed whitelist is a security boundary: file_path and
         file_type live in the same row as the editable fields."""


### PR DESCRIPTION
Lets a user correct an imported book's title, author and language.

> **Stacked on #4.** This branches from `feat-card-click-target`, not `main`, because the pencil sits beside the cover Remove button that PR introduces. Please merge #4 first. I can rebase onto `main` instead if you would rather take this one independently.

## Why

Imports routinely produce `Unknown Title` and `Unknown Author`, and there is no way to fix them.

Language matters more than it looks. `detect_language` only distinguishes Hungarian from English, so every other language is stored as `en`. Since `language` reaches the TTS engine, a Romanian book is read with English phonetics and nothing in the UI can correct it.

## What changed

**`PUT /api/books/<id>`**, mirroring the existing `PUT /api/books/<id>/characters/<id>`: JSON body, an `allowed` whitelist, dynamic `SET`, `{'ok': True, 'segments_cleared': bool}`.

`PUT` rather than `PATCH` is deliberate, to match the two partial-update endpoints already in the project.

The whitelist is a security boundary as well as a filter. `file_path` and `file_type` live in the same row, so without it a crafted request could repoint a book at any file on disk. `test_file_path_cannot_be_changed` pins that rather than assuming it.

**A pencil on the cover** opens a dialog built from the existing modal system, pre-filled with the current values.

**`list_books` now also selects `language`**, which the dialog needs to pre-fill.

## The one destructive behavior, and how it is gated

Changing the language clears that book's `tts_segments`; changing only the title or author never does.

That asymmetry is the crux. `language` is part of the audio cache key, so a new language produces new keys. But a segment that already has a file on disk is served straight from `seg['audio_path']` without the key ever being recomputed, so without clearing, a language change would leave the book permanently mispronounced on every chapter already read. Clearing on a title typo would discard hours of synthesis for nothing.

The dialog asks for confirmation before saving, and only when the language actually differs from the value it opened with.

Two tests pin this and neither can pass by accident: `test_title_only_edit_keeps_generated_audio` and `test_language_change_clears_generated_audio`.

## A bug this uncovered in the EPUB parser

`reader/core/parser/epub_parser.py:289` stores `dc:language` with no `.lower()`, so a book declaring `<dc:language>EN</dc:language>` is stored as `EN`.

An early version of this endpoint lowercased the submitted language but compared it against the raw stored value. Reproduced: a book stored as `EN`, with generated audio, edited to fix only its title, sent `en`, compared unequal, and **every segment was deleted**.

Fixed here by normalizing both sides of the comparison, with a test for exactly that case. I have not changed the EPUB parser: it is outside this PR, and normalizing at the comparison is correct regardless of what the parser writes. Happy to send a separate PR lowercasing it at import if you want the stored values consistent.

## The language field is free text

A `<datalist>` suggests `en, hu, ro, de, fr, es, it, zh, ja`, but the input accepts any code matching `^[a-z]{2}(-[a-z]{2,4})?$`.

Not a `<select>`, because nothing in the codebase or the model card enumerates what OmniVoice supports. A fixed list would either exclude languages that work or imply verified support that does not exist. The backend already treats the value as free-form: `_map_tn_lang` special-cases `en`, `zh` and `ja` and passes anything else to `num2words`.

The trade-off worth naming: a user can set a code the model handles poorly, and will have discarded their existing audio to find out. There is no way to detect that without a support list.

## Tests

**141 passing, 124 of them pre-existing and untouched.**

```
python -m unittest discover -s tests -p "test_*.py"
Ran 141 tests
OK
```

17 new tests in `reader/tests/test_book_metadata_api.py` cover both audio-clearing directions, the case-mismatch case above, a NULL-language book accepting a title-only edit, every validation rule, non-string rejection, the 404, and the `file_path` security boundary.

Per `AGENTS.md`, the dialog was checked with local Playwright plus screenshots and a console check: the pencil reveals on hover without opening the book, the dialog pre-fills, a title-only save shows no confirmation, a genuine language change does, an empty title is refused, and the console is clean.

## Known limitations

- The clear is not atomic with the update. The row is committed, then segments are deleted on a second connection. A crash between the two leaves the new language with the old audio, and re-submitting the same language will not clear again since it now matches. This mirrors the existing character-update endpoint's structure.
- Clearing removes `tts_segments` rows, not the `.wav` files, so those are orphaned on disk. Same as the existing endpoint, not a regression.
- `.card-edit` duplicates most of `.card-remove`'s styling rather than sharing a block. `.card-remove` belongs to #4, and editing it from a stacked branch invites conflicts. Worth collapsing once both land.
- Out of scope by design: editing the cover, bulk editing, undo, and re-running language detection after an edit.
