### PR TITLE
Make the file-type badge readable on light covers

### DIFF
--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -489,7 +489,7 @@ code {
 
 .book-type-badge {
   position: absolute; top: 8px; right: 8px;
-  background: rgba(0,0,0,.55); color: var(--text2);
+  background: rgba(0,0,0,.78); color: var(--text);
   font-size: 0.6rem; padding: 2px 6px; border-radius: 3px;
   font-family: 'Courier New', monospace; text-transform: uppercase;
   letter-spacing: 0.08em; backdrop-filter: blur(4px);


### PR DESCRIPTION
Makes the file-type badge readable on light cover art.

## The problem

`.book-type-badge` uses a translucent background with muted text:

```css
background: rgba(0,0,0,.55); color: var(--text2);
```

Because the background is translucent, what actually renders depends on the cover behind it.

| Cover | Composited background | Contrast against `--text2` |
| --- | --- | --- |
| Dark placeholder (`--bg3`, `#2e2b28`) | `#151312` | 4.73:1, fine |
| White cover art | `#737373` | **1.21:1** |

WCAG asks 4.5:1 for normal text. At 1.21:1 the label is effectively invisible: on an EPUB or PDF with a white cover, the badge renders as a plain grey rectangle.

That is presumably why it went unnoticed: on the dark placeholder covers it looks correct.

## The fix

```css
background: rgba(0,0,0,.78); color: var(--text);
```

8.39:1 on a white cover, 14.23:1 on a dark one. `backdrop-filter: blur(4px)` and everything else about the rule are unchanged, so the glass look survives.

**Darkening the background alone is not enough.** Keeping `--text2` and only raising the alpha still fails on white: `.78` gives 2.99:1 and even `.82` gives 3.47:1. It only clears 4.5:1 once the alpha reaches roughly 0.92, at which point the badge is essentially opaque and the blur is pointless. Changing the text colour to `--text` is what actually solves it, and it lets the background stay translucent.

## Verification

Contrast was computed from the shipped stylesheet rather than by eye, using a script that resolves `var()` references, composites the declared `rgba()` over both a white cover and the project's own dark cover, and applies the WCAG formula. The script is not part of this PR.

Before the change it reproduces the bug (`FAIL, white cover, 1.21:1`); after it reports `PASS` on both. The check was also confirmed capable of failing, by deliberately breaking the value and watching it report the failure.

Verified visually in Chromium against both a white PDF cover and a dark placeholder cover, with no console errors. The Python suite passes unchanged at 124 tests, since this is a one-line CSS change.

## Scope

One declaration line in `reader/static/css/style.css`. No JavaScript, template, Python, or dependency change, and no change to the theme variables in `:root`.
